### PR TITLE
Expose Encodings variable for ORTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Rob Deutsch](https://github.com/rob-deutsch) *RTPReceiver graceful shutdown*
 * [Jin Lei](https://github.com/jinleileiking) - *SFU example use http*
 * [Will Watson](https://github.com/wwatson) - *Enable gocritic*
+* [Luke Curley](https://github.com/kixelated)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -860,7 +860,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 		for _, tranceiver := range pc.rtpTransceivers {
 			if tranceiver.Sender != nil {
 				err = tranceiver.Sender.Send(RTPSendParameters{
-					encodings: RTPEncodingParameters{
+					Encodings: RTPEncodingParameters{
 						RTPCodingParameters{
 							SSRC:        tranceiver.Sender.track.SSRC(),
 							PayloadType: tranceiver.Sender.track.PayloadType(),
@@ -940,7 +940,7 @@ func (pc *PeerConnection) openSRTP() {
 			}
 
 			if err = receiver.Receive(RTPReceiveParameters{
-				encodings: RTPDecodingParameters{
+				Encodings: RTPDecodingParameters{
 					RTPCodingParameters{SSRC: ssrc},
 				}}); err != nil {
 				pcLog.Warnf("RTPReceiver Receive failed %s", err)

--- a/rtpreceiveparameters.go
+++ b/rtpreceiveparameters.go
@@ -2,5 +2,5 @@ package webrtc
 
 // RTPReceiveParameters contains the RTP stack settings used by receivers
 type RTPReceiveParameters struct {
-	encodings RTPDecodingParameters
+	Encodings RTPDecodingParameters
 }

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -58,7 +58,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 
 	r.track = &Track{
 		kind:     r.kind,
-		ssrc:     parameters.encodings.SSRC,
+		ssrc:     parameters.Encodings.SSRC,
 		receiver: r,
 	}
 
@@ -67,7 +67,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 		return err
 	}
 
-	srtpReadStream, err := srtpSession.OpenReadStream(parameters.encodings.SSRC)
+	srtpReadStream, err := srtpSession.OpenReadStream(parameters.Encodings.SSRC)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) error {
 		return err
 	}
 
-	srtcpReadStream, err := srtcpSession.OpenReadStream(parameters.encodings.SSRC)
+	srtcpReadStream, err := srtcpSession.OpenReadStream(parameters.Encodings.SSRC)
 	if err != nil {
 		return err
 	}

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -58,7 +58,7 @@ func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	if err != nil {
 		return err
 	}
-	srtcpReadStream, err := srtcpSession.OpenReadStream(parameters.encodings.SSRC)
+	srtcpReadStream, err := srtcpSession.OpenReadStream(parameters.Encodings.SSRC)
 	if err != nil {
 		return err
 	}

--- a/rtpsendparameters.go
+++ b/rtpsendparameters.go
@@ -2,5 +2,5 @@ package webrtc
 
 // RTPSendParameters contains the RTP stack settings used by receivers
 type RTPSendParameters struct {
-	encodings RTPEncodingParameters
+	Encodings RTPEncodingParameters
 }


### PR DESCRIPTION
It's not possible to use a RTPReceiver without it.